### PR TITLE
Extend webwatch codelab with Slack part. Make the codelabs 'timeless'…

### DIFF
--- a/memegen/codelab/memegen_codelab.md
+++ b/memegen/codelab/memegen_codelab.md
@@ -1,4 +1,4 @@
-#### ZuriHac 2016 Beginner Track Exercise
+#### ZuriHac Beginner Track Exercise
 # Web meme generator
 
 **Description:** A web application for creating [memes](https://en.wikipedia.org/wiki/Internet_meme) from pictures:
@@ -12,8 +12,7 @@
 * How to build a small, real-world web application in Haskell (no HTML or CSS
   knowledge (or work) required).
 
-**NOTE:** Instructions are tested on Ubuntu Linux 16.04, OS X. For help with
-Microsoft Windows, please email ivan.kristo@gmail.com.
+**NOTE:** Instructions are tested on Ubuntu Linux 16.04 and OS X.
 
 Let's start!
 

--- a/webwatch/README.md
+++ b/webwatch/README.md
@@ -2,9 +2,10 @@
 
 ## Introduction
 
-This is a demo beginners project for ZuriHac 2016.  It watches a certain webpage
+This is a demo beginners project for ZuriHac 2016. It watches a certain webpage
 for links with keywords (e.g. search http://news.ycombinator.com for "Haskell").
-When such a link is found, it sends you a slack message.
+When such a link is found, it sends you a slack message. See the
+[codelab](codelab/webwatch_codelab.md) for more details.
 
 ## Code layout
 
@@ -12,13 +13,13 @@ The code is organised in three modules.
 
 - `WebWatch.Links`: Scrapes a web page and pulls out links matching given
   keywords
-- `WebWatch.Slack`: Performs a POST request to a Slack webhook
+- `WebWatch.Slack`: Performs a HTTP POST request to a Slack webhook
 - `Main.hs`: Main module, reads the configuration file and then runs the
   scraper/chatbot at a configurable interval
 
 # Libraries
 
-My implementation uses the following libraries:
+The implementation uses the following libraries:
 
 - `http-client` for downloading a web page and sending a POST
 - `tagsoup` for parsing the web page and getting out the links

--- a/webwatch/src/WebWatch/Slack.hs
+++ b/webwatch/src/WebWatch/Slack.hs
@@ -1,4 +1,4 @@
--- | This module contains code for sending notification mails.
+-- | This module contains code for sending messages to the Slack channel.
 {-# LANGUAGE OverloadedStrings #-}
 module WebWatch.Slack
     ( sendLinks


### PR DESCRIPTION
… (i.e., remove the year reference :D). Update webwatch codelab to reflect the current state of the code