### PR TITLE
fix: consume the entire upload image; not just 1st chunk of the stream

### DIFF
--- a/memegen/codelab/memegen_codelab.md
+++ b/memegen/codelab/memegen_codelab.md
@@ -339,7 +339,6 @@ upload a picture. Follow the steps to add a file upload handler.
    import qualified Snap.Util.FileUploads as S
    import qualified Data.Text as T
    import qualified System.IO.Streams as IOS
-   import qualified System.IO.Streams.ByteString as IOSB
    import           Data.Text.Encoding (decodeUtf8)
    import           Control.Monad.State (liftM, liftIO)
    import           System.FilePath ((</>))
@@ -353,7 +352,7 @@ upload a picture. Follow the steps to add a file upload handler.
    uploadHandler = do
      -- Files are sent as HTTP multipart form entries.
      files <- S.handleMultipart uploadPolicy $ \part istream -> do
-       content <- fmap (fromMaybe B.empty) $ IOSB.takeBytes maxFileSize istream >>= IOS.read
+       content <- IOS.fold B.append B.empty istream
        return (part, content)
      let (imgPart, imgContent) = head files
      let fileName = fromJust (S.partFileName imgPart)
@@ -839,7 +838,7 @@ image. We will write a string onto the image using the well known
    uploadHandler :: S.Handler AppState AppState ()
    uploadHandler = do
      files <- S.handleMultipart uploadPolicy $ \part istream -> do
-       content <- fmap (fromMaybe B.empty) $ IOSB.takeBytes maxFileSize istream >>= IOS.read
+       content <- IOS.fold B.append B.empty istream
        return (part, content)
      let (imgPart, imgContent) = head files
      let fileName = fromJust (S.partFileName imgPart)

--- a/memegen/src/Memegen/Lib.hs
+++ b/memegen/src/Memegen/Lib.hs
@@ -23,7 +23,6 @@ import qualified Snap.Snaplet.SqliteSimple as S
 import qualified Snap.Util.FileServe as S
 import qualified Snap.Util.FileUploads as S
 import qualified System.IO.Streams as IOS
-import qualified System.IO.Streams.ByteString as IOSB
 import           Snap.Core (Method(..), rqPostParams, getRequest, writeBS, getParam, method)
 import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath ((</>))
@@ -76,7 +75,7 @@ uploadHandler :: S.Handler AppState AppState ()
 uploadHandler = do
   -- Files are sent as HTTP multipart form entries.
   files <- S.handleMultipart uploadPolicy $ \part istream -> do
-    content <- fmap (fromMaybe B.empty) $ IOSB.takeBytes maxFileSize istream >>= IOS.read
+    content <- IOS.fold B.append B.empty istream
     return (part, content)
   let (imgPart, imgContent) = head files
   let fileName = fromJust (S.partFileName imgPart)


### PR DESCRIPTION
- IOS.read may only return a chunk of the stream; often less than 4KB
- IOSB.takeBytes truncates the stream, but IOS.read still returns chunks
- IOS.fold combines all the chunks into one ByteString
- IOSB.takeBytes is unnecessary as uploadPolicy rejects bigger uploads